### PR TITLE
Update hooks.mjs

### DIFF
--- a/modules/hooks.mjs
+++ b/modules/hooks.mjs
@@ -228,7 +228,7 @@ export default function registerHooks() {
         if (!hasProperty(updateData, "data.attributes.hp.value") && !hasProperty(updateData, "img")) return;
         // find any matching combat carousel combatants
         
-        if (!game.combat.combatants.some(c => c.actor.id === actor.id)) return;
+        if (!game.combat?.combatants.some(c => c.actor.id === actor.id)) return;
         // update their hp bar
 
         ui.combatCarousel.render();


### PR DESCRIPTION
Fix error:
TypeError: Cannot read property 'combatants' of null
    at hooks.mjs:231
when carousel is active but there is not a combat in progress