### PR TITLE
Updated to respect PF1E's 'Hide From Tokens' setting on buffs.

### DIFF
--- a/modules/combat-carousel.mjs
+++ b/modules/combat-carousel.mjs
@@ -1674,6 +1674,11 @@ export default class CombatCarousel extends Application {
         }
         
         if (filteredEffects) {
+            if(game.system.id === 'pf1') {
+                console.log("effects", filteredEffects);
+                filteredEffects = filteredEffects.filter(e => e.data.flags.pf1?.show ?? true);
+            }
+            
             filteredEffects = filteredEffects.map(e => { 
                 return {
                     img: e.data.icon,


### PR DESCRIPTION
In the PF1E System, Buff items use Active Effects to handle icon support, but also include a boolean flag to determine whether to show or hide the icon from tokens.

This pull request allows the Combat Carousel to do the same in all filter modes by filtering for the boolean flag, if present, after the effects have been filtered by the Carousel's settings.