### PR TITLE
Fix hardcoded render condition in updateActor hook

### DIFF
--- a/modules/hooks.mjs
+++ b/modules/hooks.mjs
@@ -229,7 +229,13 @@ export default function registerHooks() {
 
         if (!enabled || !game.combat || ui.combatCarousel?._collapsed) return;
 
-        if (!hasProperty(updateData, "data.attributes.hp") && !hasProperty(updateData, "img") && !hasProperty(updateData, "name")) return;
+        // try to use system's primary attribute bar, then fallback to combat carousel setting, then fallback to matching all data updates
+        const hasUpdatedBar1 = hasProperty(updateData, ((game.system.data.primaryTokenAttribute ?? game.settings.get(NAME, SETTING_KEYS.bar1Attribute)) ?? 'data'));
+
+        const hasUpdatedOverlayProperties = game.settings.get(NAME, SETTING_KEYS.overlaySettings)
+          .filter(o => o.value).reduce((a,o) => a || hasProperty(updateData, o.value), false);
+
+        if (!hasUpdatedBar1 && !hasUpdatedOverlayProperties && !hasProperty(updateData, "img") && !hasProperty(updateData, "img") && !hasProperty(updateData, "name")) return;
         // find any matching combat carousel combatants
         
         if (!game.combat?.combatants.some(c => c.actor.id === actor.id)) return;


### PR DESCRIPTION
Solves #132

Not sure if you like the fallback behaviour of `hasUpdatedBar1`, but imho this is a good compromise between missing updates and rendering too often and the fallback shouldn't trigger for most systems either way.