### PR TITLE
Handle Setting Turn to Null

### DIFF
--- a/modules/hooks.mjs
+++ b/modules/hooks.mjs
@@ -80,12 +80,8 @@ export default function registerHooks() {
 
         if (hasProperty(update, "turn")) {
             if (update.turn !== ui.combatCarousel.turn) {
-                const combatant = combat.turns[update.turn];
-
-                if (!combatant) return;
-
                 ui.combatCarousel.turn = update.turn;
-                
+
                 return ui.combatCarousel.render();
                 //return ui.combatCarousel.setActiveCombatant(combatant);
             }


### PR DESCRIPTION
In the case that the turn is set to null, update the turn and re-render
the application anyway so that no combatant is shown as active.
